### PR TITLE
Merge latest updates used to run on 2022 data

### DIFF
--- a/NanoProd/crab/Run2_2016/data.yaml
+++ b/NanoProd/crab/Run2_2016/data.yaml
@@ -1,0 +1,9 @@
+config:
+    params:
+      era: Run2_2016
+      sampleType: data
+      storeFailed: false
+
+SingleMuon_2016F: /SingleMuon/Run2016F-UL2016_MiniAODv2-v2/MINIAOD
+SingleMuon_2016G: /SingleMuon/Run2016G-UL2016_MiniAODv2-v2/MINIAOD
+SingleMuon_2016H: /SingleMuon/Run2016H-UL2016_MiniAODv2-v2/MINIAOD

--- a/NanoProd/crab/Run2_2016/hnl_e_mu.yaml
+++ b/NanoProd/crab/Run2_2016/hnl_e_mu.yaml
@@ -1,0 +1,12 @@
+config:
+  params:
+    era: Run2_2016
+    sampleType: mc
+    storeFailed: false
+
+HNL_M-1_V-0.0794_e_V-0.0794_mu: local:/eos/user/a/amascell/HNL/output/Run2_2016/HeavyNeutrino_trilepton_M-1_V-0.0794_e_V-0.0794_mu_massiveAndCKM_LO
+HNL_M-2_V-0.00954_e_V-0.00954_mu: local:/eos/user/a/amascell/HNL/output/Run2_2016/HeavyNeutrino_trilepton_M-2_V-0.00954_e_V-0.00954_mu_massiveAndCKM_LO
+HNL_M-3_V-0.00268_e_V-0.00268_mu: local:/eos/user/a/amascell/HNL/output/Run2_2016/HeavyNeutrino_trilepton_M-3_V-0.00268_e_V-0.00268_mu_massiveAndCKM_LO
+HNL_M-4_V-0.00107_e_V-0.00107_mu: local:/eos/user/a/amascell/HNL/output/Run2_2016/HeavyNeutrino_trilepton_M-4_V-0.00107_e_V-0.00107_mu_massiveAndCKM_LO
+HNL_M-5_V-0.000528_e_V-0.000528_mu: local:/eos/user/a/amascell/HNL/output/Run2_2016/HeavyNeutrino_trilepton_M-5_V-0.000528_e_V-0.000528_mu_massiveAndCKM_LO
+HNL_M-6_V-0.000297_e_V-0.000297_mu: local:/eos/user/a/amascell/HNL/output/Run2_2016/HeavyNeutrino_trilepton_M-6_V-0.000297_e_V-0.000297_mu_massiveAndCKM_LO

--- a/NanoProd/crab/Run2_2016/hnl_mu.yaml
+++ b/NanoProd/crab/Run2_2016/hnl_mu.yaml
@@ -1,0 +1,12 @@
+config:
+  params:
+    era: Run2_2016
+    sampleType: mc
+    storeFailed: false
+
+HNL_M-1_V-0.112_mu_2016: local:/eos/user/a/amascell/HNL/output/Run2_2016/HeavyNeutrino_trilepton_M-1_V-0.112_mu_massiveAndCKM_LO
+HNL_M-2_V-0.0135_mu_2016: local:/eos/user/a/amascell/HNL/output/Run2_2016/HeavyNeutrino_trilepton_M-2_V-0.0135_mu_massiveAndCKM_LO
+HNL_M-3_V-0.00379_mu_2016: local:/eos/user/a/amascell/HNL/output/Run2_2016/HeavyNeutrino_trilepton_M-3_V-0.00379_mu_massiveAndCKM_LO
+HNL_M-4_V-0.00151_mu_2016: local:/eos/user/a/amascell/HNL/output/Run2_2016/HeavyNeutrino_trilepton_M-4_V-0.00151_mu_massiveAndCKM_LO
+HNL_M-5_V-0.000746_mu_2016: local:/eos/user/a/amascell/HNL/output/Run2_2016/HeavyNeutrino_trilepton_M-5_V-0.000746_mu_massiveAndCKM_LO
+HNL_M-6_V-0.00042_mu_2016: local:/eos/user/a/amascell/HNL/output/Run2_2016/HeavyNeutrino_trilepton_M-6_V-0.00042_mu_massiveAndCKM_LO

--- a/NanoProd/crab/Run2_2016/mc_bkg.yaml
+++ b/NanoProd/crab/Run2_2016/mc_bkg.yaml
@@ -1,0 +1,8 @@
+config:
+  params:
+    era: Run2_2016
+    sampleType: mc
+    storeFailed: false
+
+WminusJetsToMuNu: /WminusJetsToMuNu_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1/MINIAODSIM
+WplusJetsToMuNu: /WplusJetsToMuNu_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1/MINIAODSIM

--- a/NanoProd/crab/Run2_2016APV/data.yaml
+++ b/NanoProd/crab/Run2_2016APV/data.yaml
@@ -1,0 +1,12 @@
+config:
+    params:
+      era: Run2_2016_HIPM
+      sampleType: data
+      storeFailed: false
+
+SingleMuon_2016B-ver1: /SingleMuon/Run2016B-ver1_HIPM_UL2016_MiniAODv2-v2/MINIAOD
+SingleMuon_2016B-ver2: /SingleMuon/Run2016B-ver2_HIPM_UL2016_MiniAODv2-v2/MINIAOD
+SingleMuon_2016C: /SingleMuon/Run2016C-HIPM_UL2016_MiniAODv2-v2/MINIAOD
+SingleMuon_2016D: /SingleMuon/Run2016D-HIPM_UL2016_MiniAODv2-v2/MINIAOD
+SingleMuon_2016E: /SingleMuon/Run2016E-HIPM_UL2016_MiniAODv2-v2/MINIAOD
+SingleMuon_2016F-HIPM: /SingleMuon/Run2016F-HIPM_UL2016_MiniAODv2-v2/MINIAOD

--- a/NanoProd/crab/Run2_2016APV/hnl_e_mu.yaml
+++ b/NanoProd/crab/Run2_2016APV/hnl_e_mu.yaml
@@ -1,0 +1,12 @@
+config:
+  params:
+    era: Run2_2016_HIPM
+    sampleType: mc
+    storeFailed: false
+
+HNL_M-1_V-0.0794_e_V-0.0794_mu: local:/eos/user/a/amascell/HNL/output/Run2_2016APV/HeavyNeutrino_trilepton_M-1_V-0.0794_e_V-0.0794_mu_massiveAndCKM_LO
+HNL_M-2_V-0.00954_e_V-0.00954_mu: local:/eos/user/a/amascell/HNL/output/Run2_2016APV/HeavyNeutrino_trilepton_M-2_V-0.00954_e_V-0.00954_mu_massiveAndCKM_LO
+HNL_M-3_V-0.00268_e_V-0.00268_mu: local:/eos/user/a/amascell/HNL/output/Run2_2016APV/HeavyNeutrino_trilepton_M-3_V-0.00268_e_V-0.00268_mu_massiveAndCKM_LO
+HNL_M-4_V-0.00107_e_V-0.00107_mu: local:/eos/user/a/amascell/HNL/output/Run2_2016APV/HeavyNeutrino_trilepton_M-4_V-0.00107_e_V-0.00107_mu_massiveAndCKM_LO
+HNL_M-5_V-0.000528_e_V-0.000528_mu: local:/eos/user/a/amascell/HNL/output/Run2_2016APV/HeavyNeutrino_trilepton_M-5_V-0.000528_e_V-0.000528_mu_massiveAndCKM_LO
+HNL_M-6_V-0.000297_e_V-0.000297_mu: local:/eos/user/a/amascell/HNL/output/Run2_2016APV/HeavyNeutrino_trilepton_M-6_V-0.000297_e_V-0.000297_mu_massiveAndCKM_LO

--- a/NanoProd/crab/Run2_2016APV/hnl_mu.yaml
+++ b/NanoProd/crab/Run2_2016APV/hnl_mu.yaml
@@ -1,0 +1,12 @@
+config:
+  params:
+    era: Run2_2016_HIPM
+    sampleType: mc
+    storeFailed: false
+
+HNL_M-1_V-0.112_mu_2016APV: local:/eos/user/a/amascell/HNL/output/Run2_2016APV/HeavyNeutrino_trilepton_M-1_V-0.112_mu_massiveAndCKM_LO
+HNL_M-2_V-0.0135_mu_2016APV: local:/eos/user/a/amascell/HNL/output/Run2_2016APV/HeavyNeutrino_trilepton_M-2_V-0.0135_mu_massiveAndCKM_LO
+HNL_M-3_V-0.00379_mu_2016APV: local:/eos/user/a/amascell/HNL/output/Run2_2016APV/HeavyNeutrino_trilepton_M-3_V-0.00379_mu_massiveAndCKM_LO
+HNL_M-4_V-0.00151_mu_2016APV: local:/eos/user/a/amascell/HNL/output/Run2_2016APV/HeavyNeutrino_trilepton_M-4_V-0.00151_mu_massiveAndCKM_LO
+HNL_M-5_V-0.000746_mu_2016APV: local:/eos/user/a/amascell/HNL/output/Run2_2016APV/HeavyNeutrino_trilepton_M-5_V-0.000746_mu_massiveAndCKM_LO
+HNL_M-6_V-0.00042_mu_2016APV: local:/eos/user/a/amascell/HNL/output/Run2_2016APV/HeavyNeutrino_trilepton_M-6_V-0.00042_mu_massiveAndCKM_LO

--- a/NanoProd/crab/Run2_2016APV/mc_bkg.yaml
+++ b/NanoProd/crab/Run2_2016APV/mc_bkg.yaml
@@ -1,0 +1,8 @@
+config:
+  params:
+    era: Run2_2016
+    sampleType: mc
+    storeFailed: false
+
+WminusJetsToMuNu: /WminusJetsToMuNu_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/MINIAODSIM
+WplusJetsToMuNu: /WplusJetsToMuNu_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/MINIAODSIM

--- a/NanoProd/crab/Run2_2017/data.yaml
+++ b/NanoProd/crab/Run2_2017/data.yaml
@@ -1,0 +1,13 @@
+config:
+    params:
+      era: Run2_2017
+      sampleType: data
+      storeFailed: false
+
+SingleMuon_2017B: /SingleMuon/Run2017B-UL2017_MiniAODv2-v1/MINIAOD
+SingleMuon_2017C: /SingleMuon/Run2017C-UL2017_MiniAODv2-v1/MINIAOD
+SingleMuon_2017D: /SingleMuon/Run2017D-UL2017_MiniAODv2-v1/MINIAOD
+SingleMuon_2017E: /SingleMuon/Run2017E-UL2017_MiniAODv2-v1/MINIAOD
+SingleMuon_2017F: /SingleMuon/Run2017F-UL2017_MiniAODv2-v1/MINIAOD
+SingleMuon_2017G: /SingleMuon/Run2017G-UL2017_MiniAODv2-v1/MINIAOD
+SingleMuon_2017H: /SingleMuon/Run2017H-UL2017_MiniAODv2-v1/MINIAOD

--- a/NanoProd/crab/Run2_2017/hnl_e_mu.yaml
+++ b/NanoProd/crab/Run2_2017/hnl_e_mu.yaml
@@ -1,0 +1,12 @@
+config:
+  params:
+    era: Run2_2017
+    sampleType: mc
+    storeFailed: false
+
+HNL_M-1_V-0.0794_e_V-0.0794_mu: local:/eos/user/a/amascell/HNL/output/Run2_2017/HeavyNeutrino_trilepton_M-1_V-0.0794_e_V-0.0794_mu_massiveAndCKM_LO
+HNL_M-2_V-0.00954_e_V-0.00954_mu: local:/eos/user/a/amascell/HNL/output/Run2_2017/HeavyNeutrino_trilepton_M-2_V-0.00954_e_V-0.00954_mu_massiveAndCKM_LO
+HNL_M-3_V-0.00268_e_V-0.00268_mu: local:/eos/user/a/amascell/HNL/output/Run2_2017/HeavyNeutrino_trilepton_M-3_V-0.00268_e_V-0.00268_mu_massiveAndCKM_LO
+HNL_M-4_V-0.00107_e_V-0.00107_mu: local:/eos/user/a/amascell/HNL/output/Run2_2017/HeavyNeutrino_trilepton_M-4_V-0.00107_e_V-0.00107_mu_massiveAndCKM_LO
+HNL_M-5_V-0.000528_e_V-0.000528_mu: local:/eos/user/a/amascell/HNL/output/Run2_2017/HeavyNeutrino_trilepton_M-5_V-0.000528_e_V-0.000528_mu_massiveAndCKM_LO
+HNL_M-6_V-0.000297_e_V-0.000297_mu: local:/eos/user/a/amascell/HNL/output/Run2_2017/HeavyNeutrino_trilepton_M-6_V-0.000297_e_V-0.000297_mu_massiveAndCKM_LO

--- a/NanoProd/crab/Run2_2017/hnl_mu.yaml
+++ b/NanoProd/crab/Run2_2017/hnl_mu.yaml
@@ -1,0 +1,12 @@
+config:
+  params:
+    era: Run2_2017
+    sampleType: mc
+    storeFailed: false
+
+HNL_M-1_V-0.112_mu: local:/eos/user/a/amascell/HNL/output/Run2_2017/HeavyNeutrino_trilepton_M-1_V-0.112_mu_massiveAndCKM_LO
+HNL_M-2_V-0.0135_mu: local:/eos/user/a/amascell/HNL/output/Run2_2017/HeavyNeutrino_trilepton_M-2_V-0.0135_mu_massiveAndCKM_LO
+HNL_M-3_V-0.00379_mu: local:/eos/user/a/amascell/HNL/output/Run2_2017/HeavyNeutrino_trilepton_M-3_V-0.00379_mu_massiveAndCKM_LO
+HNL_M-4_V-0.00151_mu: local:/eos/user/a/amascell/HNL/output/Run2_2017/HeavyNeutrino_trilepton_M-4_V-0.00151_mu_massiveAndCKM_LO
+HNL_M-5_V-0.000746_mu: local:/eos/user/a/amascell/HNL/output/Run2_2017/HeavyNeutrino_trilepton_M-5_V-0.000746_mu_massiveAndCKM_LO
+HNL_M-6_V-0.00042_mu: local:/eos/user/a/amascell/HNL/output/Run2_2017/HeavyNeutrino_trilepton_M-6_V-0.00042_mu_massiveAndCKM_LO

--- a/NanoProd/crab/Run2_2018/hnl_e_mu.yaml
+++ b/NanoProd/crab/Run2_2018/hnl_e_mu.yaml
@@ -1,0 +1,12 @@
+config:
+  params:
+    era: Run2_2018
+    sampleType: mc
+    storeFailed: false
+
+HNL_M-1_V-0.0794_e_V-0.0794_mu: local:/eos/user/a/amascell/HNL/output/Run2_2018/HeavyNeutrino_trilepton_M-1_V-0.0794_e_V-0.0794_mu_massiveAndCKM_LO
+HNL_M-2_V-0.00954_e_V-0.00954_mu: local:/eos/user/a/amascell/HNL/output/Run2_2018/HeavyNeutrino_trilepton_M-2_V-0.00954_e_V-0.00954_mu_massiveAndCKM_LO
+HNL_M-3_V-0.00268_e_V-0.00268_mu: local:/eos/user/a/amascell/HNL/output/Run2_2018/HeavyNeutrino_trilepton_M-3_V-0.00268_e_V-0.00268_mu_massiveAndCKM_LO
+HNL_M-4_V-0.00107_e_V-0.00107_mu: local:/eos/user/a/amascell/HNL/output/Run2_2018/HeavyNeutrino_trilepton_M-4_V-0.00107_e_V-0.00107_mu_massiveAndCKM_LO
+HNL_M-5_V-0.000528_e_V-0.000528_mu: local:/eos/user/a/amascell/HNL/output/Run2_2018/HeavyNeutrino_trilepton_M-5_V-0.000528_e_V-0.000528_mu_massiveAndCKM_LO
+HNL_M-6_V-0.000297_e_V-0.000297_mu: local:/eos/user/a/amascell/HNL/output/Run2_2018/HeavyNeutrino_trilepton_M-6_V-0.000297_e_V-0.000297_mu_massiveAndCKM_LO

--- a/NanoProd/crab/Run2_2018/hnl_mu.yaml
+++ b/NanoProd/crab/Run2_2018/hnl_mu.yaml
@@ -4,9 +4,9 @@ config:
     sampleType: mc
     storeFailed: false
 
-HNL_M-1_V-0.112_mu: local:/eos/user/a/amascell/HNL/output/Run2_2018_noMinLz/HeavyNeutrino_trilepton_M-1_V-0.112_mu_massiveAndCKM_LO
-HNL_M-2_V-0.0135_mu: local:/eos/user/a/amascell/HNL/output/Run2_2018_noMinLz/HeavyNeutrino_trilepton_M-2_V-0.0135_mu_massiveAndCKM_LO
-HNL_M-3_V-0.00379_mu: local:/eos/user/a/amascell/HNL/output/Run2_2018_noMinLz/HeavyNeutrino_trilepton_M-3_V-0.00379_mu_massiveAndCKM_LO
-HNL_M-4_V-0.00151_mu: local:/eos/user/a/amascell/HNL/output/Run2_2018_noMinLz/HeavyNeutrino_trilepton_M-4_V-0.00151_mu_massiveAndCKM_LO
-HNL_M-5_V-0.000746_mu: local:/eos/user/a/amascell/HNL/output/Run2_2018_noMinLz/HeavyNeutrino_trilepton_M-5_V-0.000746_mu_massiveAndCKM_LO
-HNL_M-6_V-0.00042_mu: local:/eos/user/a/amascell/HNL/output/Run2_2018_noMinLz/HeavyNeutrino_trilepton_M-6_V-0.00042_mu_massiveAndCKM_LO
+HNL_M-1_V-0.112_mu: local:/eos/user/a/amascell/HNL/output/Run2_2018/HeavyNeutrino_trilepton_M-1_V-0.112_mu_massiveAndCKM_LO
+HNL_M-2_V-0.0135_mu: local:/eos/user/a/amascell/HNL/output/Run2_2018/HeavyNeutrino_trilepton_M-2_V-0.0135_mu_massiveAndCKM_LO
+HNL_M-3_V-0.00379_mu: local:/eos/user/a/amascell/HNL/output/Run2_2018/HeavyNeutrino_trilepton_M-3_V-0.00379_mu_massiveAndCKM_LO
+HNL_M-4_V-0.00151_mu: local:/eos/user/a/amascell/HNL/output/Run2_2018/HeavyNeutrino_trilepton_M-4_V-0.00151_mu_massiveAndCKM_LO
+HNL_M-5_V-0.000746_mu: local:/eos/user/a/amascell/HNL/output/Run2_2018/HeavyNeutrino_trilepton_M-5_V-0.000746_mu_massiveAndCKM_LO
+HNL_M-6_V-0.00042_mu: local:/eos/user/a/amascell/HNL/output/Run2_2018/HeavyNeutrino_trilepton_M-6_V-0.00042_mu_massiveAndCKM_LO

--- a/NanoProd/crab/Run3_2022/data_2022CDE.yaml
+++ b/NanoProd/crab/Run3_2022/data_2022CDE.yaml
@@ -1,0 +1,9 @@
+config:
+    params:
+      era: Run3_2022CDE
+      sampleType: data
+      storeFailed: false
+
+Muon_2022C: /Muon/Run2022C-27Jun2023-v1/MINIAOD
+Muon_2022D: /Muon/Run2022D-27Jun2023-v2/MINIAOD
+Muon_2022E: /Muon/Run2022E-27Jun2023-v1/MINIAOD

--- a/NanoProd/crab/Run3_2022/data_2022FG.yaml
+++ b/NanoProd/crab/Run3_2022/data_2022FG.yaml
@@ -1,0 +1,8 @@
+config:
+    params:
+      era: Run3_2022FG
+      sampleType: data
+      storeFailed: false
+
+Muon_2022F: /Muon/Run2022F-PromptReco-v1/MINIAOD
+Muon_2022G: /Muon/Run2022G-PromptReco-v1/MINIAOD

--- a/NanoProd/crab/Run3_2022/hnl_mu.yaml
+++ b/NanoProd/crab/Run3_2022/hnl_mu.yaml
@@ -1,0 +1,12 @@
+config:
+  params:
+    era: Run3_2022
+    sampleType: mc
+    storeFailed: false
+
+HNL_M-1_V-0.112_mu: local:/eos/home-k/kandroso/cms-hnl/Run3/Run3Summer22/HeavyNeutrino_trilepton_M-1_V-0.112_mu_massiveAndCKM_LO
+HNL_M-2_V-0.0135_mu: local:/eos/home-k/kandroso/cms-hnl/Run3/Run3Summer22/HeavyNeutrino_trilepton_M-2_V-0.0135_mu_massiveAndCKM_LO
+HNL_M-3_V-0.00379_mu: local:/eos/home-k/kandroso/cms-hnl/Run3/Run3Summer22/HeavyNeutrino_trilepton_M-3_V-0.00379_mu_massiveAndCKM_LO
+HNL_M-4_V-0.00151_mu: local:/eos/home-k/kandroso/cms-hnl/Run3/Run3Summer22/HeavyNeutrino_trilepton_M-4_V-0.00151_mu_massiveAndCKM_LO
+HNL_M-5_V-0.000746_mu: local:/eos/home-k/kandroso/cms-hnl/Run3/Run3Summer22/HeavyNeutrino_trilepton_M-5_V-0.000746_mu_massiveAndCKM_LO
+HNL_M-6_V-0.00042_mu: local:/eos/home-k/kandroso/cms-hnl/Run3/Run3Summer22/HeavyNeutrino_trilepton_M-6_V-0.00042_mu_massiveAndCKM_LO

--- a/NanoProd/crab/crab_test.yaml
+++ b/NanoProd/crab/crab_test.yaml
@@ -1,10 +1,10 @@
 config:
   params:
-    era: Run2_2018
+    era: Run3_2022CDE
     sampleType: data
     storeFailed: false
     maxEvents: 100
     customiseCmds: "process.Timing = cms.Service('Timing', summaryOnly=cms.untracked.bool(True)); process.SimpleMemoryCheck = cms.Service('SimpleMemoryCheck', jobReportOutputOnly=cms.untracked.bool(True)); process.CPU = cms.Service('CPU')"
   dryrun: true
 
-SingleMuon_2018D: /SingleMuon/Run2018D-UL2018_MiniAODv2_GT36-v1/MINIAOD
+SingleMuon_2022C: /Muon/Run2022C-27Jun2023-v1/MINIAOD

--- a/NanoProd/crab/overseer_cfg.yaml
+++ b/NanoProd/crab/overseer_cfg.yaml
@@ -1,6 +1,6 @@
 cmsswPython: RunKit/nanoProdWrapper.py
 params:
-  customise: HNL/NanoProd/DiMuon_cff.nanoAOD_customizeDisplacedDiMuon
+  customise: HNL/NanoProd/DiMuon_cff.nanoAOD_customizeDisplacedDiMuon_Run3
   skimCfg: skim_mu.yaml
   skimSetup: skim
   skimSetupFailed: skim_failed

--- a/NanoProd/crab/overseer_cfg.yaml
+++ b/NanoProd/crab/overseer_cfg.yaml
@@ -17,6 +17,8 @@ filesToTransfer:
   - RunKit/skim_tree.py
   - RunKit/sh_tools.py
   - HNL/NanoProd/config/skim_mu.yaml
+  - HNL/NanoProd/python/DiMuon_cff.py
+  - HNL/NanoProd/python/common_cff.py
 
 # Update destination site and paths before launching a production
 site: T3_CH_CERNBOX

--- a/NanoProd/plugins/KinVtxFitter.cc
+++ b/NanoProd/plugins/KinVtxFitter.cc
@@ -21,6 +21,8 @@ KinVtxFitter::KinVtxFitter(const std::vector<reco::TransientTrack>& tracks,
   }
 
   KinematicParticleVertexFitter kcv_fitter;
+  // Move secondary vertex cutoff to the end of the muon system
+  kcv_fitter.setTrackerBounds(650., 1000.);
   RefCountedKinematicTree vtx_tree = kcv_fitter.fit(particles);
 
   if (vtx_tree->isEmpty() || !vtx_tree->isValid() || !vtx_tree->isConsistent()) {

--- a/NanoProd/python/DiMuon_cff.py
+++ b/NanoProd/python/DiMuon_cff.py
@@ -1,7 +1,30 @@
+import importlib
+import os
 import sys
 import FWCore.ParameterSet.Config as cms
 from PhysicsTools.NanoAOD.common_cff import CandVars, Var, P3Vars
-from HNL.NanoProd.common_cff import ufloat, uint, ubool
+
+def load(module_file, default_path):
+  print(f'BASE PATH: {os.path.join(os.getenv("CMSSW_BASE"), "..", module_file)}')
+  module_path = os.path.join(default_path, module_file)
+  if not os.path.exists(module_path):
+    module_path = os.path.join(os.path.dirname(__file__), module_file)
+    if not os.path.exists(module_path):
+      module_path = os.path.join(os.getenv("CMSSW_BASE"), 'src', module_file)
+      if not os.path.exists(module_path):
+        module_path = os.path.join(os.getenv("CMSSW_BASE"), '..', module_file)
+        if not os.path.exists(module_path):
+          raise RuntimeError(f"Cannot find path to {module_file}.")
+
+  module_name, module_ext = os.path.splitext(module_file)
+  spec = importlib.util.spec_from_file_location(module_name, module_path)
+  module = importlib.util.module_from_spec(spec)
+  sys.modules[module_name] = module
+  spec.loader.exec_module(module)
+  return module
+
+common_cff = load('common_cff.py', os.path.join(os.getenv("CMSSW_BASE"), 'src/HNL/NanoProd/python/'))
+from common_cff import ufloat, uint, ubool
 
 
 def defineSelectedDSAFilter(isDSATracks, isRun2):


### PR DESCRIPTION
- Add 2022 config
- Correctly set SV cutoff
- Make the nanoAOD processing run on crab